### PR TITLE
Security Rules Working cloud/rtdb in add/edit/delete (most updated branch)

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,6 +1,13 @@
 {
   "rules": {
-    ".read": "now < 1688194800000",  // 2023-7-1
-    ".write": "now < 1688194800000",  // 2023-7-1
+    ".read": "auth !== null",
+    "users": {
+      "$uid": {
+        ".write": "auth.uid === $uid"
+      }
+    },
+    "posts": {
+      ".write": "true"
+    }
   }
 }

--- a/src/Components/addCardForm/addCard.tsx
+++ b/src/Components/addCardForm/addCard.tsx
@@ -53,27 +53,29 @@ export default function CardForm({
       };
 
       window.addEventListener("beforeunload", handleBeforeUnload);
-
-      const newPostKey = await writePost(
-        {
-          title: currentTitle,
-          description: currentDesc,
-          imageUrl: imageSubmitted!,
-        },
-        user!,
-        newFile!
-      );
-
-      addPost([
-        {
-          title: currentTitle,
-          description: currentDesc,
-          imageUrl: imageSubmitted!,
-          postKey: newPostKey!,
-        },
-      ]);
-      clearForm();
-      window.removeEventListener("beforeunload", handleBeforeUnload);
+      try {
+        const newPostKey = await writePost(
+          {
+            title: currentTitle,
+            description: currentDesc,
+            imageUrl: imageSubmitted!,
+          },
+          user!,
+          newFile!
+        );
+        addPost([
+          {
+            title: currentTitle,
+            description: currentDesc,
+            imageUrl: imageSubmitted!,
+            postKey: newPostKey!,
+          },
+        ]);
+        clearForm();
+        window.removeEventListener("beforeunload", handleBeforeUnload);
+      } catch (error) {
+        alert(error);
+      }
     }
     loadingScreen(false);
   }

--- a/src/Components/addCardForm/addCardUtils.ts
+++ b/src/Components/addCardForm/addCardUtils.ts
@@ -26,7 +26,6 @@ export default async function writePost(
 ) {
   const postKey = push(ref(database, "posts/")).key;
   const postRef = storageRef(storage, `users/${currentUser.uid!}/${postKey}`);
-
   await uploadBytes(postRef, file);
   const url = await getDownloadURL(postRef);
   await update(ref(database, "posts/" + postKey), {

--- a/src/Components/editCardForm/editCardUtils.ts
+++ b/src/Components/editCardForm/editCardUtils.ts
@@ -26,24 +26,24 @@ export default async function editPost(
   newFile: File,
   authorUID: string | undefined
 ) {
+  await update(ref(database, `users/${authorUID}/posts/${postKey}/`), {
+    cardTitle: title,
+    cardDescription: description,
+  });
+  await update(ref(database, "posts/" + postKey), {
+    cardTitle: title,
+    cardDescription: description,
+  });
   if (newFile) {
     const postRef = storageRef(storage, `users/${authorUID}/${postKey}`);
     await deleteObject(postRef);
     await uploadBytes(postRef, newFile);
     const url = await getDownloadURL(postRef);
-    await update(ref(database, "posts/" + postKey), {
-      cardImage: url,
-    });
     await update(ref(database, `users/${authorUID}/posts/${postKey}/`), {
       cardImage: url,
     });
+    await update(ref(database, "posts/" + postKey), {
+      cardImage: url,
+    });
   }
-  await update(ref(database, "posts/" + postKey), {
-    cardTitle: title,
-    cardDescription: description,
-  });
-  await update(ref(database, `users/${authorUID}/posts/${postKey}/`), {
-    cardTitle: title,
-    cardDescription: description,
-  });
 }

--- a/src/pages/cardScreen/cardScreenUtils.ts
+++ b/src/pages/cardScreen/cardScreenUtils.ts
@@ -20,9 +20,8 @@ export async function removeCurrentCard(
   currentPostKey: string,
   authorUID: string | undefined
 ) {
-  console.log(authorUID);
-  const postRef = storageRef(storage, `users/${authorUID}/${currentPostKey}`);
-  await deleteObject(postRef);
   await remove(ref(database, `users/${authorUID}/posts/${currentPostKey}`));
   await remove(ref(database, `posts/${currentPostKey}`));
+  const postRef = storageRef(storage, `users/${authorUID}/${currentPostKey}`);
+  await deleteObject(postRef);
 }


### PR DESCRIPTION
Rearranged methods to do "user/" path check for RTDB at the beginning of each operation, since it was easier to implement the json rules for that conditional. Doing "posts/" check afterwards to achieve same output was more complicated. Still can be added on for extra extra security later if we want.